### PR TITLE
Remove placeholder text and footer links

### DIFF
--- a/src/main/resources/theme/konveyor/login/template.ftl
+++ b/src/main/resources/theme/konveyor/login/template.ftl
@@ -149,18 +149,6 @@
           </main>
 
           <#--  <footer class="pf-c-login__footer">
-            <p>This is placeholder text only. Use this area to place any information or introductory message about your application that may be relevant to users.</p>
-            <ul class="pf-c-list pf-m-inline">
-              <li>
-                <a href="#" target="_blank" rel="noopener noreferrer">Terms of use</a>
-              </li>
-              <li>
-                <a href="#" target="_blank" rel="noopener noreferrer">Help</a>
-              </li>
-              <li>
-                <a href="#" target="_blank" rel="noopener noreferrer">Privacy policy</a>
-              </li>
-            </ul>
           </footer>  -->
         </div>
       </div>


### PR DESCRIPTION
- Remove sample placeholder text from template

Probably docker images need to be re-created afterwards if not using quay.io autobuild triggers