### PR TITLE
fix: migrate from k8s.gcr.io to registry.k8s.io

### DIFF
--- a/Dockerfile.init
+++ b/Dockerfile.init
@@ -1,4 +1,4 @@
-FROM k8s.gcr.io/busybox 
+FROM registry.k8s.io/busybox 
 
 ADD target/tackle-keycloak-theme-*.jar /
 


### PR DESCRIPTION
This fix is a part of an umbrella issue https://github.com/kubernetes/k8s.io/issues/4780